### PR TITLE
Remove check for video size

### DIFF
--- a/routes/room.js
+++ b/routes/room.js
@@ -22,22 +22,14 @@ router.post('/join', (req, res) => {
                 }
             )
         } else {
-            if(room.videoSize != videoSize) {
-                res.send(
-                    {
-                        message: "video is different than the host's video."
-                    }
-                )
-            } else {
-                res.send(
-                    {
-                        roomCode,
-                        videoSize,
-                        roomName: room.roomName,
-                        message: "success"
-                    }
-                )
-            }
+            res.send(
+                {
+                    roomCode,
+                    videoSize,
+                    roomName: room.roomName,
+                    message: "success"
+                }
+            )
         }
     })
 })


### PR DESCRIPTION
Different video sizes don't mean that videos are different. I've had a couple of scenarios where due to a bug in browser (or OS), it ends up downloading a slightly different number of bytes than the other user.

There could be a check for the duration of video which would be more accurate, but not having these checks won't hurt anyone :)